### PR TITLE
Add new quirks for SOL001 parsing

### DIFF
--- a/tosca/grammars/tosca_v1_1/unit.go
+++ b/tosca/grammars/tosca_v1_1/unit.go
@@ -18,6 +18,10 @@ func ReadUnit(context *tosca.Context) tosca.EntityPtr {
 
 	self := tosca_v2_0.NewUnit(context)
 	context.ScriptletNamespace.Merge(DefaultScriptletNamespace)
-	context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions"))
+	if context.HasQuirk(tosca.QuirkImportsTopologyTemplateIgnore) {
+		context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions", "topology_template"))
+	} else {
+		context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions"))
+	}
 	return self
 }

--- a/tosca/grammars/tosca_v1_2/unit.go
+++ b/tosca/grammars/tosca_v1_2/unit.go
@@ -19,6 +19,10 @@ func ReadUnit(context *tosca.Context) tosca.EntityPtr {
 
 	self := tosca_v2_0.NewUnit(context)
 	context.ScriptletNamespace.Merge(DefaultScriptletNamespace)
-	context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions"))
+	if context.HasQuirk(tosca.QuirkImportsTopologyTemplateIgnore) {
+		context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions", "topology_template"))
+	} else {
+		context.ValidateUnsupportedFields(append(context.ReadFields(self), "dsl_definitions"))
+	}
 	return self
 }

--- a/tosca/grammars/tosca_v2_0/requirement-mapping.go
+++ b/tosca/grammars/tosca_v2_0/requirement-mapping.go
@@ -94,7 +94,9 @@ func (self *RequirementMapping) Render() {
 	}
 
 	if !found {
-		self.Context.ListChild(1, name).ReportReferenceNotFound("requirement", self.NodeTemplate)
+		if !self.Context.HasQuirk(tosca.QuirkSubstitutionMappingsRequirementsAllowDangling) {
+			self.Context.ListChild(1, name).ReportReferenceNotFound("requirement", self.NodeTemplate)
+		}
 	}
 }
 

--- a/tosca/quirk.go
+++ b/tosca/quirk.go
@@ -44,7 +44,14 @@ const QuirkNamespaceNormativeShortcutsDisable Quirk = "namespace.normative.short
 // quirk changes the expected syntax to be a sequenced list.
 const QuirkSubstitutionMappingsRequirementsList Quirk = "substitution_mappings.requirements.list"
 
+// ETSI SOL001 2.x mandates usage of imports that contain topology_template
+// this quirk ignores topology_template in imports
 //
+const QuirkImportsTopologyTemplateIgnore Quirk = "imports.ignore.topology_template"
+
+// ETSI SOL001 2.x needs substitutionmappings using unassigned referenced
+const QuirkSubstitutionMappingsRequirementsAllowDangling Quirk = "substitution_mappings.requirements.allow_dangling"
+
 // Quirks
 //
 


### PR DESCRIPTION
This PR merges in a single commit all the changes originally discussed in PR#58
2 new quirks are added
imports.ignore.topology_template
  ignore topology_template in imported units
substitution_mappings.requirements.allow_dangling
  allow a requirement in substitution_mapping to point to an
  undeclared requirement of a node in node_template